### PR TITLE
Add some tests to withStyles HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react": "^3.16.1",
     "jsdom": "^7.1.1",
     "mocha": "^2.3.4",
+    "react": "^0.14.7",
     "rimraf": "^2.5.1",
     "sinon": "^1.17.2"
   },

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -9,13 +9,18 @@
 
 import React, { Component, PropTypes } from 'react';
 
+function getDisplayName(ComposedComponent) {
+  return ComposedComponent.displayName || ComposedComponent.name || 'Component';
+}
+
 function withStyles(ComposedComponent, ...styles) {
-  return class Styles extends Component {
+  return class WithStyles extends Component {
     static contextTypes = {
       insertCss: PropTypes.func.isRequired,
     };
 
-    static displayName = ComposedComponent.displayName || ComposedComponent.name;
+    static displayName = `WithStyles(${getDisplayName(ComposedComponent)})`;
+    static ComposedComponent = ComposedComponent;
 
     componentWillMount() {
       this.removeCss = this.context.insertCss.apply(undefined, styles);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,7 @@
 {
   "rules": {
-    "no-unused-expressions": 0
+    "no-unused-expressions": 0,
+    "react/no-multi-comp": 0,
+    "react/prefer-es6-class": 0
   }
 }

--- a/test/withStylesSpec.js
+++ b/test/withStylesSpec.js
@@ -1,0 +1,50 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import React, { createClass, Component } from 'react';
+import withStyles from '../src/withStyles';
+
+describe('withStyles(ComposedComponent, ...styles)', () => {
+  class Passthrough extends Component {
+    render() {
+      return <div {...this.props} />;
+    }
+  }
+
+  it('Should set the displayName correctly', () => {
+    expect(withStyles(
+      class Foo extends Component {
+        render() {
+          return <div />;
+        }
+      }
+    ).displayName).to.equal('WithStyles(Foo)');
+
+    expect(withStyles(
+      createClass({
+        displayName: 'Bar',
+        render() {
+          return <div />;
+        },
+      })
+    ).displayName).to.equal('WithStyles(Bar)');
+
+    expect(withStyles(
+      createClass({
+        render() {
+          return <div />;
+        },
+      })
+    ).displayName).to.equal('WithStyles(Component)');
+  });
+
+  it('Should expose the component with styles as ComposedComponent', () => {
+    class Container extends Component {
+      render() {
+        return <Passthrough />;
+      }
+    }
+
+    const decorated = withStyles(Container);
+    expect(decorated.ComposedComponent).to.equal(Container);
+  });
+});


### PR DESCRIPTION
- Rename high-order component name to actual `WithStyles`
- Use different names for unstyled and composed components
- Add `ComposedComponent` static property to original component class passed to `withStyles`
- Add `withStylesSpec.js` with two tests
- Add missing `react` devDependency