### PR TITLE
Fix style not getting removed for multiple instance

### DIFF
--- a/src/insertCss.js
+++ b/src/insertCss.js
@@ -52,6 +52,8 @@ function insertCss(styles, options) {
     const [moduleId, css, media, sourceMap] = styles[i];
     const id = `${moduleId}-${i}`;
 
+    ids.push(id);
+
     if (inserted[id]) {
       if (!replace) {
         inserted[id]++;
@@ -60,7 +62,6 @@ function insertCss(styles, options) {
     }
 
     inserted[id] = 1;
-    ids.push(id);
 
     let elem = document.getElementById(prefix + id);
     let create = false;


### PR DESCRIPTION
When we insert multiple instance of a styled component to same page,`removeCss` function will be called with empty array for all the instance except the first one.

The reason for this issue is, `ids.push(id);` will get called only if the style is not inserted, so we'll bind empty array to `removeCss`