### PR TITLE
Add ref for ComposedComponent

### DIFF
--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -31,7 +31,7 @@ function withStyles(...styles) {
     }
 
     render() {
-      return <ComposedComponent {...this.props} />;
+      return <ComposedComponent ref="composedComponent" {...this.props} />;
     }
   };
 }


### PR DESCRIPTION
Expose `ref` for the `ComposedComponent` to enable workflows that require `ReactDOM.findDOMNode()` on the `WithStyles` wrapper.