### PR TITLE
Make sourceURL unique

### DIFF
--- a/src/insertCss.js
+++ b/src/insertCss.js
@@ -82,7 +82,7 @@ function insertCss(styles, options) {
     if (sourceMap) {
       cssText += `\n/*# sourceMappingURL=data:application/json;base64,${
         b64EncodeUnicode(JSON.stringify(sourceMap))}*/`;
-      cssText += `\n/*# sourceURL=${sourceMap.file}*/`;
+      cssText += `\n/*# sourceURL=${id}*/`;
     }
 
     if ('textContent' in elem) {


### PR DESCRIPTION
The [sourceMap 3 sepcification](https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k/edit) mentions
sourceURL is described [here](http://blog.getfirebug.com/2009/08/11/give-your-eval-a-name-with-sourceurl/), which mentions that
> The name has to uniquely identify the buffer

Where `map.file` is currently not, so for example if I have multiple `style.scss` files in my project,
clicking on chrome's inspector's diplayed filename will always take me to some specific one and not the correct one.
( mabye the first one, not sure. )

![screen shot 2016-06-01 at 11 38 53 am](https://cloud.githubusercontent.com/assets/326402/15703405/b7a159f0-27ed-11e6-8efc-42dbd0c4a265.png)

Making sourceURL a unique identifier fixes that.