### PR TITLE
use HMR if available, no debug option required

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ module.exports.pitch = function pitch(remainingRequest) {
   }
 
   const insertCssPath = path.join(__dirname, './insertCss.js');
-  let output = `
+  return `
     var content = require(${stringifyRequest(this, `!!${remainingRequest}`)});
     var insertCss = require(${stringifyRequest(this, `!${insertCssPath}`)});
 
@@ -28,9 +28,7 @@ module.exports.pitch = function pitch(remainingRequest) {
     module.exports = content.locals || {};
     module.exports._getCss = function() { return content.toString(); };
     module.exports._insertCss = function(options) { return insertCss(content, options) };
-  `;
-
-  output += this.debug ? `
+    
     // Hot Module Replacement
     // https://webpack.github.io/docs/hot-module-replacement
     // Only activated in browser context
@@ -47,7 +45,5 @@ module.exports.pitch = function pitch(remainingRequest) {
       });
       module.hot.dispose(function() { removeCss(); });
     }
-  ` : '';
-
-  return output;
+  `;
 };


### PR DESCRIPTION
This fix has two advantages: simplifies configuration and works with webpack 2.