### PR TITLE
Fixes for React 15.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ $ npm install isomorphic-style-loader --save-dev
 
 ```js
 // MyComponent.js
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import withStyles from 'isomorphic-style-loader/lib/withStyles';
 import s from './MyComponent.scss';
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "babel-runtime": "^6.11.6",
     "hoist-non-react-statics": "^1.2.0",
-    "loader-utils": "^0.2.16"
+    "loader-utils": "^0.2.16",
+    "prop-types": "^15.5.8"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",
@@ -63,6 +64,7 @@
     "babel-register": "^6.16.3",
     "chai": "^3.5.0",
     "coveralls": "^2.11.14",
+    "create-react-class": "^15.5.2",
     "eslint": "^3.7.1",
     "eslint-config-airbnb": "^12.0.0",
     "eslint-plugin-import": "^1.16.0",

--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -7,7 +7,8 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import hoistStatics from 'hoist-non-react-statics';
 
 const contextTypes = {

--- a/test/withStyles.spec.js
+++ b/test/withStyles.spec.js
@@ -11,7 +11,9 @@ import jsdom from 'jsdom';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import React, { createClass, Component, Children, PropTypes } from 'react';
+import React, { Component, Children } from 'react';
+import createClass from 'create-react-class';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import withStyles from '../src/withStyles';
 


### PR DESCRIPTION
- Pull PropTypes from prop-types package
- Use createClass from create-react-class

Fixes #89