### PR TITLE
Semicolon in docs causes code to not run

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const port = process.env.PORT || 3000;
 // Server-side rendering of the React app
 server.get('*', (req, res, next) =>
   const css = new Set(); // CSS for all rendered React components
-  const context = { insertCss: (...styles) => styles.forEach(style => css.add(style._getCss())); };
+  const context = { insertCss: (...styles) => styles.forEach(style => css.add(style._getCss())) };
   router.dispatch({ ...req, context }).then((component, state) => {
     const body = ReactDOM.renderToString(component);
     const html = `<!doctype html>


### PR DESCRIPTION
Hey, just a little typo in the docs. This function is at the terminus of an object definition so no semicolon