### PR TITLE
Move babel dependencies to dependency section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isomorphic-style-loader",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "CSS style loader for Webpack optimized for critical path CSS rendering and isomoprhic web apps",
   "repository": "kriasoft/isomorphic-style-loader",
   "author": "Kriasoft <hello@kriasoft.com> (https://www.kriasoft.com)",
@@ -59,15 +59,15 @@
     "babel-runtime": "^6.23.0",
     "hoist-non-react-statics": "^2.0.0",
     "loader-utils": "^1.1.0",
-    "prop-types": "^15.5.10"
+    "prop-types": "^15.5.10",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-latest": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-latest": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
     "babel-register": "^6.24.1",
     "chai": "^4.0.2",
     "coveralls": "^2.13.1",


### PR DESCRIPTION
This PR is more about to start a discussion.

When using isomorphic-style-loader in my nested dependency, it throws errors as follows.

`Module build failed: ReferenceError: Unknown plugin "transform-runtime" specified in...`
or
`Module build failed: Error: Couldn't find preset "latest" relative to directory...`

I believe this error is because of these babel dependencies (which i moved) are specified as devDependency.  

I managed to solve my problem by install these three dependencies to my `builder` module. But this is a temporary solution.

Actually i think maybe babel is broken because there is so much issues around like this. for example: https://github.com/tommikaikkonen/redux-orm/issues/24  
