### PR TITLE
componentWillUnmount safetey

### DIFF
--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -23,7 +23,9 @@ function withStyles(...styles) {
       }
 
       componentWillUnmount() {
-        setTimeout(this.removeCss, 0);
+        if (this.removeCss) {
+          setTimeout(this.removeCss, 0);
+        }
       }
 
       render() {


### PR DESCRIPTION
Added a safety check on `componentWillUnmount` of `withStyles` to only `setTimeout` if `this.removeCss` is defined.

This fixes an issue I was seeing them using this component in tandem with my `enzyme` tests.