### PR TITLE
Fix build failure: Change target Node versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - '6'
-  - '5'
-  - '4'
+  - 'stable'
+  - 10
+  - 8
+  - 6
 script:
   - npm run lint
   - npm run test:cover


### PR DESCRIPTION
* Remove versions out of maintainance
    * `error slash@2.0.0: The engine "node" is incompatible with this module. Expected version ">=6".`
* Test against latest stable and LTSs in maintainance