### PR TITLE
Use stable public context API

### DIFF
--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -15,9 +15,9 @@ import StyleContext from './StyleContext'
 function withStyles(...styles) {
   return function wrapWithStyles(ComposedComponent) {
     class WithStyles extends React.PureComponent {
-      constructor(props, context) {
-        super(props, context)
-        this.removeCss = context.insertCss(...styles)
+      constructor(props) {
+        super(props)
+        this.removeCss = this.context.insertCss(...styles)
       }
 
       componentWillUnmount() {


### PR DESCRIPTION
Fixes #150 

## Motivation
See #150. I'm seeing an error that I'm having a hard time diagnosing, and I think it may be related to using something other than the context API described in the react docs.

## Changes
* Remove `context` as a constructor argument
* Reference context via `this`

## Testing
See that a page loads on a server-side rendered application.