### PR TITLE
Move react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   "main": "src/index.js",
   "dependencies": {
     "hoist-non-react-statics": "^3.0.0",
-    "loader-utils": "^1.2.3",
+    "loader-utils": "^1.2.3"
+  },
+  "peerDependencies": {
     "react": "^16.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jest": "^24.1.0",
     "prettier": "^1.16.4",
     "prop-types": "^15.7.2",
+    "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "rollup": "^1.2.1",
     "rollup-plugin-babel": "^4.3.2",


### PR DESCRIPTION
Fixes #155 

## Motivation
See #155. When `react` is a dependency of a React-related package, it's possible for multiple instances of React to end up floating around in the bundled/executed code. This isn't always a problem, but recent changes to hooks and context in React have made it that much more likely for it to become a problem.

Moving `react` to a `peerDependency` means that it's up to the consumer to install `react`, but it also makes it that much less likely that this library will cause problems in other people's applications.

## Changes
* Move React to a `peerDependency`