### PR TITLE
Output hot module logics on demand

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ module.exports.pitch = function pitch(request) {
 
   const insertCss = require.resolve('./insertCss.js')
   return `
-    var refs = 0;
     var css = require(${stringifyRequest(this, `!!${request}`)});
     var insertCss = require(${stringifyRequest(this, `!${insertCss}`)});
     var content = typeof css === 'string' ? [[module.id, css, '']] : css;
@@ -27,6 +26,7 @@ module.exports.pitch = function pitch(request) {
     exports._getCss = function() { return '' + css; };
     exports._insertCss = function(options) { return insertCss(content, options) };
 
+    ${this.hot ? `
     // Hot Module Replacement
     // https://webpack.github.io/docs/hot-module-replacement
     // Only activated in browser context
@@ -39,5 +39,6 @@ module.exports.pitch = function pitch(request) {
       });
       module.hot.dispose(function() { removeCss(); });
     }
+  ` : ''}
   `
 }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,9 @@ module.exports.pitch = function pitch(request) {
     exports._getCss = function() { return '' + css; };
     exports._insertCss = function(options) { return insertCss(content, options) };
 
-    ${this.hot ? `
+    ${
+      this.hot
+        ? `
     // Hot Module Replacement
     // https://webpack.github.io/docs/hot-module-replacement
     // Only activated in browser context
@@ -39,6 +41,8 @@ module.exports.pitch = function pitch(request) {
       });
       module.hot.dispose(function() { removeCss(); });
     }
-  ` : ''}
+  `
+        : ''
+    }
   `
 }

--- a/test/insertCss.test.js
+++ b/test/insertCss.test.js
@@ -25,7 +25,10 @@ describe('insertCss(styles, options)', () => {
   it('Should insert and remove multiple <style> elements for a single module', () => {
     const css1 = 'body { color: red; }'
     const css2 = 'body { color: blue; }'
-    const removeCss = insertCss([[1, css1], [1, css2]])
+    const removeCss = insertCss([
+      [1, css1],
+      [1, css2],
+    ])
     let style = global.document.getElementsByTagName('style')
     expect(style).toHaveLength(2)
     expect(style[0].textContent).toBe(css1)


### PR DESCRIPTION
According to the webpack docs https://webpack.js.org/api/loaders/#thishot

we can know if HMR is enabled during `COMPILE PHASE`.

The current code increase unnecessary codes in production. ( Hot Module Reload is never enabled in production)

Hope this little change may help generating smaller output codes.

I also found that `refs` variable is never used, so it could be removed safely.

