### PR TITLE
chore(dependencies): enable react 17 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8.2",
-    "react-dom": "^16.8.2"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.3",


### PR DESCRIPTION
Enables support for React 17, as I see no reason why this should not work on 17.