### PR TITLE
fix(withstyles): prop-types were incomplete

### DIFF
--- a/src/withStyles.js
+++ b/src/withStyles.js
@@ -36,11 +36,16 @@ function withStyles(...styles) {
     const displayName = ComposedComponent.displayName || ComposedComponent.name || 'Component'
 
     WithStyles.propTypes = {
-      __$$withStylesRef: PropTypes.func,
+      __$$withStylesRef: PropTypes.oneOfType([
+        PropTypes.func,
+        PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+      ]),
     }
+
     WithStyles.defaultProps = {
       __$$withStylesRef: undefined,
     }
+
     WithStyles.contextType = StyleContext
 
     const ForwardedWithStyles = React.forwardRef((props, ref) => (


### PR DESCRIPTION
This enables us to use refs without a warning in dev mode

```
  const ref = useRef();
  // ...
  withStyles(<Component ref={ref} />)
```

Before only functions were allowed