### PR TITLE
Replacement of 198

### DIFF
--- a/src/useStyles.js
+++ b/src/useStyles.js
@@ -7,13 +7,10 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import { useContext, useEffect } from 'react'
+import { useContext, useLayoutEffect } from 'react'
 import StyleContext from './StyleContext'
 
-// To detect if it's in SSR process or in browser. Wrapping with
-// the function makes rollup's replacement of "this" avoidable
-// eslint-disable-next-line func-names
-const isBrowser = (() => this && typeof this.window === 'object')()
+const isBrowser = typeof window !== 'undefined'
 
 function useStyles(...styles) {
   const { insertCss } = useContext(StyleContext)
@@ -25,7 +22,7 @@ function useStyles(...styles) {
     }
   }
   if (isBrowser) {
-    useEffect(runEffect, [])
+    useLayoutEffect(runEffect, [])
   } else {
     runEffect()
   }


### PR DESCRIPTION
https://github.com/kriasoft/isomorphic-style-loader/pull/198

fix(useStyles): correct broken isBrowser detection and insert styles before paint

The arrow-function `this` was transpiled to `undefined`, so isBrowser was always falsy: styles were inserted during render in the browser and cleanup never ran. Use `typeof window !== 'undefined'` instead and switch to useLayoutEffect so styles are inserted before paint (no FOUC).

Based on #198.